### PR TITLE
Bug fix for generating arrayOf(Objects)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 .travis.yml
+src
 __tests__

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,2 @@
 .travis.yml
-src
 __tests__

--- a/__tests__/__snapshots__/propTypes.js.snap
+++ b/__tests__/__snapshots__/propTypes.js.snap
@@ -2,6 +2,13 @@
 
 exports[`fakeProps should return an object with all props faked (snapshot) 1`] = `
 Object {
+  "arrayOfObjects": Array [
+    Object {
+      "age": 1,
+      "isGood": true,
+      "name": "arrayOfObjects.name",
+    },
+  ],
   "customArrayProp": Array [
     "custom type not supported, please set the correct value for customArrayProp prop",
   ],

--- a/fixtures/propTypes/Component.jsx
+++ b/fixtures/propTypes/Component.jsx
@@ -43,6 +43,14 @@ MyComponent.propTypes = {
 
   // An array of a certain type
   optionalArrayOf: PropTypes.arrayOf(PropTypes.number),
+  // An array of objects
+  arrayOfObjects: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string,
+      age: PropTypes.number,
+      isGood: PropTypes.bool
+    })
+  ),
 
   // An object with property values of a certain type
   optionalObjectOf: PropTypes.objectOf(PropTypes.number),

--- a/src/index.js
+++ b/src/index.js
@@ -3,107 +3,107 @@ const React = require('react')
 const reactDocs = require('react-docgen')
 
 function isFlow(prop) {
-  return prop.flowType
+    return prop.flowType
 }
 
 function getEnum(values) {
-  return values[0].value
+    return values[0].value
 }
 
-function getUnion(prefix, values) {
-  const type = values[0]
-  return getFakeProp(prefix, { type })
+function getUnion(prefix, values, opts) {
+    const type = values[0]
+    return getFakeProp(prefix, { type }, opts)
 }
 
-function getArrayOf(prefix, type) {
-  return [getFakeProp(prefix, { type })]
+function getArrayOf(prefix, type, opts) {
+    return [getFakeProp(prefix, { type }, opts)]
 }
 
-function getObjectOf(prefix, type) {
-  return { prop: getFakeProp(prefix, { type }) }
+function getObjectOf(prefix, type, opts) {
+    return { prop: getFakeProp(prefix, { type }, opts) }
 }
 
 function getShape(prefix, object, opts) {
-  const res = {}
-  Object.keys(object).forEach(key => {
-    const type = object[key]
-    if (type.required || opts.optional) {
-      res[key] = getFakeProp(`${prefix}.${key}`, { type })
-    }
-  })
-  return res
+    const res = {}
+    Object.keys(object).forEach(key => {
+        const type = object[key]
+        if (type.required || opts.optional) {
+            res[key] = getFakeProp(`${prefix}.${key}`, { type })
+        }
+    })
+    return res
 }
 
 function getFakePropType(prefix, prop, opts) {
-  switch (prop.type.name) {
-    case 'array':
-      return []
-    case 'bool':
-      return true
-    case 'func':
-      return function fakeFunction() {}
-    case 'number':
-      return 1
-    case 'object':
-      return {}
-    case 'string':
-      return prefix
-    case 'symbol':
-      return Symbol()
-    case 'node':
-      return prefix
-    case 'element':
-      return React.createElement('div', [], `fake ${prefix} element`)
-    case 'instanceOf':
-      return `instanceOf type not supported, please set the correct value for ${prefix} prop`
-    case 'enum':
-      return getEnum(prop.type.value)
-    case 'union':
-      return getUnion(prefix, prop.type.value)
-    case 'arrayOf':
-      return getArrayOf(prefix, prop.type.value)
-    case 'objectOf':
-      return getObjectOf(prefix, prop.type.value)
-    case 'shape':
-      return getShape(prefix, prop.type.value, opts)
-    case 'any':
-      return 'any'
-    case 'custom':
-      return `custom type not supported, please set the correct value for ${prefix} prop`
-    default:
-      return 'Error, unknown type'
-  }
+    switch (prop.type.name) {
+        case 'array':
+            return []
+        case 'bool':
+            return true
+        case 'func':
+            return function fakeFunction() {}
+        case 'number':
+            return 1
+        case 'object':
+            return {}
+        case 'string':
+            return prefix
+        case 'symbol':
+            return Symbol()
+        case 'node':
+            return prefix
+        case 'element':
+            return React.createElement('div', [], `fake ${prefix} element`)
+        case 'instanceOf':
+            return `instanceOf type not supported, please set the correct value for ${prefix} prop`
+        case 'enum':
+            return getEnum(prop.type.value)
+        case 'union':
+            return getUnion(prefix, prop.type.value, opts)
+        case 'arrayOf':
+            return getArrayOf(prefix, prop.type.value, opts)
+        case 'objectOf':
+            return getObjectOf(prefix, prop.type.value, opts)
+        case 'shape':
+            return getShape(prefix, prop.type.value, opts)
+        case 'any':
+            return 'any'
+        case 'custom':
+            return `custom type not supported, please set the correct value for ${prefix} prop`
+        default:
+            return 'Error, unknown type'
+    }
 }
 
 function getFakeFlow(prefix, prop, opts) {
-  switch (prop.flowType.name) {
-    // TODO handle types defined here
-    // https://github.com/reactjs/react-docgen#types
-    default:
-      return 'Error, unknown type'
-  }
+    switch (prop.flowType.name) {
+        // TODO handle types defined here
+        // https://github.com/reactjs/react-docgen#types
+        default:
+            return 'Error, unknown type'
+    }
 }
 
 function getFakeProp(prefix, prop, opts) {
-  return isFlow(prop)
-    ? getFakeFlow(prefix, prop, opts)
-    : getFakePropType(prefix, prop, opts)
+    return isFlow(prop)
+        ? getFakeFlow(prefix, prop, opts)
+        : getFakePropType(prefix, prop, opts)
 }
 
 module.exports = function fakeProps(file, { optional = false } = {}) {
-  const source = fs.readFileSync(file)
-  const componentInfo = reactDocs.parse(source)
+    const source = fs.readFileSync(file)
+    const componentInfo = reactDocs.parse(source)
 
-  const { props } = componentInfo
-  const result = {}
+    const { props } = componentInfo
+    const result = {}
 
-  Object.keys(props).forEach(key => {
-    const prop = props[key]
+    Object.keys(props).forEach(key => {
+        const prop = props[key]
 
-    if (prop.required || optional) {
-      result[key] = getFakeProp(key, prop, { optional })
-    }
-  })
+        if (prop.required || optional) {
+            result[key] = getFakeProp(key, prop, { optional })
+        }
+    })
 
-  return result
+    return result
 }


### PR DESCRIPTION
`react-fake-props` was throwing an exception when trying to generate array of objects. The options parameter was not passed around during mutually recursive call for `getFakeProp`. 

I have also updated the jest snapshot to include `arrayOf(shape)` prop type.

Let me know if I need to add any other tests. Thanks for the library!