### PR TITLE
Suggestion of getting component info from all exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -248,7 +248,7 @@ function fakeDataForProps (props = {}, { optional = false } = {}) {
 
 module.exports = function (file, { optional = false } = {}) {
   const source = fs.readFileSync(file)
-  const componentInfo = reactDocs.parse(source)
+  const componentInfo = reactDocs.parse(source, reactDocs.resolver.findAllComponentDefinitions)
 
   return fakeDataForProps(componentInfo.props, { optional })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -253,4 +253,4 @@ module.exports = function (file, { optional = false } = {}) {
   return fakeDataForProps(componentInfo.props, { optional })
 }
 
-exports.fakeDataForProps = fakeDataForProps
+module.exports.fakeDataForProps = fakeDataForProps


### PR DESCRIPTION
Regarding to this [issue](https://github.com/typicode/react-fake-props/issues/13) - it may be a good thing to use this as a new way of getting all exports, as we else never could define more than one export in our React Components. This would be a breaking change.